### PR TITLE
Add temporal sampling to land/ocean offset check

### DIFF
--- a/src/nc_check/checks/ocean.py
+++ b/src/nc_check/checks/ocean.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, TypeAlias
 import numpy as np
 import xarray as xr
 
-from ..core.check import Check, CheckInfo, CheckResult
+from ..core.check import Check, CheckInfo, CheckResult, CheckStatus
 from ..core.coverage import (
     indices_to_ranges,
     leaf_statuses,
@@ -404,12 +404,12 @@ class LandOceanOffsetCheck(Check):
                 "note": "Skipped land/ocean sanity check because grid does not appear global.",
             }
 
-        section = (
+        first_section = (
             context.da
             if context.time_dim is None
-            else context.da.isel({context.time_dim: -1})
+            else context.da.isel({context.time_dim: 0})
         )
-        if np.issubdtype(section.dtype, np.bool_):
+        if np.issubdtype(first_section.dtype, np.bool_):
             return {
                 "enabled": True,
                 "status": "skipped_bool_dtype",
@@ -421,7 +421,15 @@ class LandOceanOffsetCheck(Check):
                 "note": "Skipped land/ocean sanity check for boolean data.",
             }
 
+        # Determine time indices to sample: [0, halfway, end], deduplicated
+        if context.time_dim is None:
+            time_indices: list[int | None] = [None]
+        else:
+            time_size = int(context.da.sizes[context.time_dim])
+            time_indices = list(dict.fromkeys([0, time_size // 2, time_size - 1]))
+
         def check_points(
+            section: xr.DataArray,
             points: tuple[tuple[str, float, float], ...],
             *,
             expected_missing: bool,
@@ -458,33 +466,73 @@ class LandOceanOffsetCheck(Check):
                 )
             return mismatches
 
-        land_mismatches = check_points(_LAND_REFERENCE_POINTS, expected_missing=True)
-        ocean_mismatches = check_points(_OCEAN_REFERENCE_POINTS, expected_missing=False)
-        mismatch_count = len(land_mismatches) + len(ocean_mismatches)
-        return {
+        time_results: list[dict[str, Any]] = []
+        for ti in time_indices:
+            section = (
+                context.da if ti is None else context.da.isel({context.time_dim: ti})
+            )
+            land_mm = check_points(section, _LAND_REFERENCE_POINTS, expected_missing=True)
+            ocean_mm = check_points(section, _OCEAN_REFERENCE_POINTS, expected_missing=False)
+            entry: dict[str, Any] = {
+                "mismatch_count": len(land_mm) + len(ocean_mm),
+                "land_mismatches": land_mm,
+                "ocean_mismatches": ocean_mm,
+            }
+            if ti is not None:
+                entry["time_index"] = ti
+            time_results.append(entry)
+
+        failed = sum(1 for r in time_results if r["mismatch_count"] > 0)
+        total = len(time_results)
+        if failed == total:
+            status = "fail"
+        elif failed > 0:
+            status = "warn"
+        else:
+            status = "pass"
+
+        report: dict[str, Any] = {
             "enabled": True,
-            "status": "fail" if mismatch_count else "pass",
-            "mismatch_count": mismatch_count,
+            "status": status,
+            "mismatch_count": sum(r["mismatch_count"] for r in time_results),
             "land_points_checked": len(_LAND_REFERENCE_POINTS),
             "ocean_points_checked": len(_OCEAN_REFERENCE_POINTS),
-            "land_mismatches": land_mismatches,
-            "ocean_mismatches": ocean_mismatches,
+            "land_mismatches": [m for r in time_results for m in r["land_mismatches"]],
+            "ocean_mismatches": [m for r in time_results for m in r["ocean_mismatches"]],
         }
+        if context.time_dim is not None:
+            report["sampled_time_indices"] = list(time_indices)
+            report["time_results"] = time_results
+        return report
 
     def check(self, ds: xr.Dataset) -> CheckResult:
         report = self.run_report(ds)
-        status = status_from_leaf_statuses([str(report.get("status", ""))])
+        raw_status = str(report.get("status", ""))
+        status = status_from_leaf_statuses([raw_status])
         mismatch_count = int(report.get("mismatch_count", 0))
-        if str(report.get("status", "")).startswith("skip"):
+        if raw_status.startswith("skip"):
             message = "Land/ocean offset check skipped."
+            suggested_fix = None
+        elif status == CheckStatus.warn:
+            time_results = report.get("time_results", [])
+            failed = sum(1 for r in time_results if r["mismatch_count"] > 0)
+            total = len(time_results)
+            message = f"Land/ocean mismatches at {failed}/{total} sampled time steps."
+            suggested_fix = "Run the time_cover check to investigate temporal data coverage."
         elif mismatch_count > 0:
             message = f"Detected {mismatch_count} land/ocean mismatches."
+            suggested_fix = None
         else:
             message = "No land/ocean offset mismatches detected."
+            suggested_fix = None
         return CheckResult(
             check_id=self.id,
             status=status,
-            info=CheckInfo(message=message, details={"report": report}),
+            info=CheckInfo(
+                message=message,
+                details={"report": report},
+                suggested_fix=suggested_fix,
+            ),
             fixable=False,
             tags=list(self.tags),
         )

--- a/src/nc_check/checks/ocean.py
+++ b/src/nc_check/checks/ocean.py
@@ -473,6 +473,17 @@ class LandOceanOffsetCheck(Check):
             )
             land_mm = check_points(section, _LAND_REFERENCE_POINTS, expected_missing=True)
             ocean_mm = check_points(section, _OCEAN_REFERENCE_POINTS, expected_missing=False)
+
+            if ti is not None:
+                time_coord = context.da.coords.get(context.time_dim)
+                time_val_str: str | None = None
+                if time_coord is not None:
+                    time_val_str = value_label(np.asarray(time_coord.values)[ti])
+                for m in land_mm + ocean_mm:
+                    m["time_index"] = ti
+                    if time_val_str is not None:
+                        m["time_value"] = time_val_str
+
             entry: dict[str, Any] = {
                 "mismatch_count": len(land_mm) + len(ocean_mm),
                 "land_mismatches": land_mm,

--- a/src/nc_check/checks/ocean.py
+++ b/src/nc_check/checks/ocean.py
@@ -506,8 +506,8 @@ class LandOceanOffsetCheck(Check):
             "enabled": True,
             "status": status,
             "mismatch_count": sum(r["mismatch_count"] for r in time_results),
-            "land_points_checked": len(_LAND_REFERENCE_POINTS),
-            "ocean_points_checked": len(_OCEAN_REFERENCE_POINTS),
+            "land_points_checked": len(_LAND_REFERENCE_POINTS) * len(time_indices),
+            "ocean_points_checked": len(_OCEAN_REFERENCE_POINTS) * len(time_indices),
             "land_mismatches": [m for r in time_results for m in r["land_mismatches"]],
             "ocean_mismatches": [m for r in time_results for m in r["ocean_mismatches"]],
         }

--- a/src/nc_check/formatting.py
+++ b/src/nc_check/formatting.py
@@ -379,13 +379,10 @@ def _render_ocean_report_with_rich(console: Any, report: dict[str, Any]) -> None
         )
     )
     offset_status = _stringify(offset.get("status"))
-    summary_rows.append(
-        (
-            "land_ocean_offset",
-            offset_status,
-            f"mismatches={_stringify(offset.get('mismatch_count', 0))}",
-        )
-    )
+    offset_desc = f"mismatches={_stringify(offset.get('mismatch_count', 0))}"
+    if offset_status == "warn":
+        offset_desc += " — run time_cover check"
+    summary_rows.append(("land_ocean_offset", offset_status, offset_desc))
     if time_missing:
         time_status = _stringify(time_missing.get("status"))
         summary_rows.append(
@@ -542,6 +539,22 @@ def _render_ocean_report_with_rich(console: Any, report: dict[str, Any]) -> None
                 _stringify(expected_value),
             )
         console.print(table)
+
+    _offset_time_indices = offset.get("sampled_time_indices")
+    _land_mm_count = len(offset.get("land_mismatches") or [])
+    _ocean_mm_count = len(offset.get("ocean_mismatches") or [])
+    if _offset_time_indices is not None or _land_mm_count or _ocean_mm_count:
+        mm_info = Table(show_header=False, box=None, pad_edge=False)
+        mm_info.add_column("k", style=_RICH_LABEL_STYLE, justify="left")
+        mm_info.add_column("v", style=_RICH_TEXT_STYLE, justify="left")
+        if _offset_time_indices is not None:
+            mm_info.add_row(
+                "Time indices checked",
+                ", ".join(str(i) for i in _offset_time_indices),
+            )
+        mm_info.add_row("Land missing points", str(_land_mm_count))
+        mm_info.add_row("Ocean missing points", str(_ocean_mm_count))
+        console.print(mm_info)
 
     _print_mismatch_table("Land Mismatches", offset.get("land_mismatches"))
     _print_mismatch_table("Ocean Mismatches", offset.get("ocean_mismatches"))
@@ -1546,17 +1559,17 @@ def _ocean_report_sections(report: dict[str, Any]) -> str:
         ]
     )
 
+    _offset_status_html = _stringify(offset.get("status"))
+    _offset_desc_html = f"mismatches={_stringify(offset.get('mismatch_count', 0))}"
+    if _offset_status_html == "warn":
+        _offset_desc_html += " — run time_cover check"
     summary_rows: list[tuple[str, Any, str]] = [
         (
             "edge_of_map",
             edge.get("status"),
             f"missing_longitudes={_stringify(edge.get('missing_longitude_count', 0))}",
         ),
-        (
-            "land_ocean_offset",
-            offset.get("status"),
-            f"mismatches={_stringify(offset.get('mismatch_count', 0))}",
-        ),
+        ("land_ocean_offset", _offset_status_html, _offset_desc_html),
     ]
     if time_missing:
         summary_rows.append(
@@ -1626,6 +1639,26 @@ def _ocean_report_sections(report: dict[str, Any]) -> str:
             _html_static_section(
                 "Time Missing Slice Ranges",
                 _html_table(["Start", "End", "Start idx", "End idx"], time_rows),
+            )
+        )
+
+    _offset_time_indices_html = offset.get("sampled_time_indices")
+    _land_mm_list = offset.get("land_mismatches") or []
+    _ocean_mm_list = offset.get("ocean_mismatches") or []
+    if _offset_time_indices_html is not None or _land_mm_list or _ocean_mm_list:
+        mm_meta_rows: list[tuple[str, Any]] = []
+        if _offset_time_indices_html is not None:
+            mm_meta_rows.append(
+                (
+                    "Time indices checked",
+                    ", ".join(str(i) for i in _offset_time_indices_html),
+                )
+            )
+        mm_meta_rows.append(("Land missing points", len(_land_mm_list)))
+        mm_meta_rows.append(("Ocean missing points", len(_ocean_mm_list)))
+        sections.append(
+            _html_static_section(
+                "Land/Ocean Offset Details", _html_summary_table(mm_meta_rows)
             )
         )
 

--- a/src/nc_check/formatting.py
+++ b/src/nc_check/formatting.py
@@ -563,8 +563,14 @@ def _render_ocean_report_with_rich(console: Any, report: dict[str, Any]) -> None
                 "Time indices checked",
                 ", ".join(str(i) for i in _offset_time_indices),
             )
-        mm_info.add_row("Land missing points", str(_land_mm_count))
-        mm_info.add_row("Ocean missing points", str(_ocean_mm_count))
+        mm_info.add_row(
+            "Land missing points",
+            f"{_land_mm_count} / {_stringify(offset.get('land_points_checked', '?'))}",
+        )
+        mm_info.add_row(
+            "Ocean missing points",
+            f"{_ocean_mm_count} / {_stringify(offset.get('ocean_points_checked', '?'))}",
+        )
         console.print(mm_info)
 
     _print_mismatch_table("Land Mismatches", offset.get("land_mismatches"))
@@ -1665,8 +1671,18 @@ def _ocean_report_sections(report: dict[str, Any]) -> str:
                     ", ".join(str(i) for i in _offset_time_indices_html),
                 )
             )
-        mm_meta_rows.append(("Land missing points", len(_land_mm_list)))
-        mm_meta_rows.append(("Ocean missing points", len(_ocean_mm_list)))
+        mm_meta_rows.append(
+            (
+                "Land missing points",
+                f"{len(_land_mm_list)} / {_stringify(offset.get('land_points_checked', '?'))}",
+            )
+        )
+        mm_meta_rows.append(
+            (
+                "Ocean missing points",
+                f"{len(_ocean_mm_list)} / {_stringify(offset.get('ocean_points_checked', '?'))}",
+            )
+        )
         sections.append(
             _html_static_section(
                 "Land/Ocean Offset Details", _html_summary_table(mm_meta_rows)

--- a/src/nc_check/formatting.py
+++ b/src/nc_check/formatting.py
@@ -512,11 +512,16 @@ def _render_ocean_report_with_rich(console: Any, report: dict[str, Any]) -> None
     def _print_mismatch_table(title_text: str, mismatches: Any) -> None:
         if not isinstance(mismatches, list) or not mismatches:
             return
+        has_time = any(
+            isinstance(e, dict) and "time_value" in e for e in mismatches
+        )
         table = Table(
             title=title_text,
             title_style=_RICH_TITLE_STYLE,
             header_style=_RICH_HEADER_STYLE,
         )
+        if has_time:
+            table.add_column("Time", style=_RICH_TEXT_STYLE, justify="left")
         table.add_column("Point", style=_RICH_TEXT_STYLE, justify="left")
         table.add_column("Requested", style=_RICH_TEXT_STYLE, justify="left")
         table.add_column("Actual", style=_RICH_TEXT_STYLE, justify="left")
@@ -531,13 +536,19 @@ def _render_ocean_report_with_rich(console: Any, report: dict[str, Any]) -> None
             expected_value = entry.get("expected_value")
             if expected_value is None:
                 expected_value = entry.get("expected_missing")
-            table.add_row(
+            row = (
+                [_stringify(entry.get("time_value", entry.get("time_index")))]
+                if has_time
+                else []
+            )
+            row += [
                 _stringify(entry.get("point")),
                 f"({_stringify(entry.get('requested_lat'))}, {_stringify(entry.get('requested_lon'))})",
                 f"({_stringify(entry.get('actual_lat'))}, {_stringify(entry.get('actual_lon'))})",
                 _stringify(observed_value),
                 _stringify(expected_value),
-            )
+            ]
+            table.add_row(*row)
         console.print(table)
 
     _offset_time_indices = offset.get("sampled_time_indices")
@@ -1669,8 +1680,16 @@ def _ocean_report_sections(report: dict[str, Any]) -> str:
         mismatches = offset.get(key)
         if not isinstance(mismatches, list) or not mismatches:
             continue
+        has_time_col = any(
+            isinstance(e, dict) and "time_value" in e for e in mismatches
+        )
         rows = [
-            [
+            (
+                [escape(_stringify(entry.get("time_value", entry.get("time_index"))))]
+                if has_time_col
+                else []
+            )
+            + [
                 escape(_stringify(entry.get("point"))),
                 escape(
                     f"({_stringify(entry.get('requested_lat'))}, {_stringify(entry.get('requested_lon'))})"
@@ -1692,17 +1711,18 @@ def _ocean_report_sections(report: dict[str, Any]) -> str:
             for entry in mismatches
             if isinstance(entry, dict)
         ]
+        headers = (["Time"] if has_time_col else []) + [
+            "Point",
+            "Requested",
+            "Actual",
+            "Observed value",
+            "Expected value",
+        ]
         sections.append(
             _html_static_section(
                 title,
                 _html_table(
-                    [
-                        "Point",
-                        "Requested",
-                        "Actual",
-                        "Observed value",
-                        "Expected value",
-                    ],
+                    headers,
                     rows,
                 ),
             )

--- a/tests/test_ocean.py
+++ b/tests/test_ocean.py
@@ -112,6 +112,114 @@ def test_land_ocean_offset_check_skips_boolean_dtype() -> None:
     assert "boolean data" in offset["note"]
 
 
+def _make_aligned_2d(
+    lon: np.ndarray, lat: np.ndarray
+) -> np.ndarray:
+    """Return a 2D float array with known land points set to NaN."""
+    data = np.ones((lat.size, lon.size), dtype=float)
+    land_points = [(23, 13), (-25, 134), (47, 103), (72, -40), (-15, -60)]
+    for plat, plon in land_points:
+        lat_idx = int(np.argmin(np.abs(lat - plat)))
+        lon_idx = int(np.argmin(np.abs(lon - plon)))
+        data[lat_idx, lon_idx] = np.nan
+    return data
+
+
+def test_land_ocean_offset_check_with_time_all_pass() -> None:
+    lon = np.arange(-180.0, 181.0, 1.0)
+    lat = np.arange(-90.0, 91.0, 1.0)
+    time = np.arange(5)
+    slice_2d = _make_aligned_2d(lon, lat)
+    data = np.stack([slice_2d] * time.size, axis=0)  # (time, lat, lon)
+
+    ds = xr.Dataset(
+        data_vars={"sst": (("time", "lat", "lon"), data)},
+        coords={"time": time, "lat": lat, "lon": lon},
+    )
+
+    report = check_ocean_cover(
+        ds,
+        var_name="sst",
+        check_edge_of_map=False,
+        report_format="python",
+    )
+
+    offset = report["land_ocean_offset"]
+    assert offset["status"] == "pass"
+    assert offset["mismatch_count"] == 0
+    assert offset["sampled_time_indices"] == [0, 2, 4]
+    assert all(r["mismatch_count"] == 0 for r in offset["time_results"])
+
+
+def test_land_ocean_offset_check_with_time_all_fail() -> None:
+    lon = np.arange(-180.0, 181.0, 1.0)
+    lat = np.arange(-90.0, 91.0, 1.0)
+    time = np.arange(5)
+    # Shift data so all time steps fail
+    slice_2d = _make_aligned_2d(lon, lat)
+    shifted = np.roll(slice_2d, 20, axis=1)
+    data = np.stack([shifted] * time.size, axis=0)
+
+    ds = xr.Dataset(
+        data_vars={"sst": (("time", "lat", "lon"), data)},
+        coords={"time": time, "lat": lat, "lon": lon},
+    )
+
+    report = check_ocean_cover(
+        ds,
+        var_name="sst",
+        check_edge_of_map=False,
+        report_format="python",
+    )
+
+    offset = report["land_ocean_offset"]
+    assert offset["status"] == "fail"
+    assert offset["mismatch_count"] > 0
+    assert offset["sampled_time_indices"] == [0, 2, 4]
+    assert all(r["mismatch_count"] > 0 for r in offset["time_results"])
+
+
+def test_land_ocean_offset_check_with_time_partial_fail() -> None:
+    lon = np.arange(-180.0, 181.0, 1.0)
+    lat = np.arange(-90.0, 91.0, 1.0)
+    # 5 time steps; index 0 (and halfway=2) pass, index 4 (end) is shifted
+    time = np.arange(5)
+    good_slice = _make_aligned_2d(lon, lat)
+    bad_slice = np.roll(good_slice, 20, axis=1)
+    data = np.stack(
+        [good_slice, good_slice, good_slice, good_slice, bad_slice], axis=0
+    )
+
+    ds = xr.Dataset(
+        data_vars={"sst": (("time", "lat", "lon"), data)},
+        coords={"time": time, "lat": lat, "lon": lon},
+    )
+
+    report = check_ocean_cover(
+        ds,
+        var_name="sst",
+        check_edge_of_map=False,
+        report_format="python",
+    )
+
+    offset = report["land_ocean_offset"]
+    assert offset["status"] == "warn"
+    assert offset["sampled_time_indices"] == [0, 2, 4]
+    # time index 4 (end) fails, the other two pass
+    failed_results = [r for r in offset["time_results"] if r["mismatch_count"] > 0]
+    passed_results = [r for r in offset["time_results"] if r["mismatch_count"] == 0]
+    assert len(failed_results) == 1
+    assert len(passed_results) == 2
+    # CheckResult should carry a suggested_fix mentioning time_cover
+    from nc_check.checks.ocean import LandOceanOffsetCheck
+    check = LandOceanOffsetCheck(
+        var_name="sst", lon_name="lon", lat_name="lat", time_name="time"
+    )
+    result = check.check(ds)
+    assert result.info.suggested_fix is not None
+    assert "time_cover" in result.info.suggested_fix
+
+
 def test_time_cover_reports_ranges() -> None:
     lon = np.arange(0.0, 360.0, 60.0)
     lat = np.array([-45.0, 45.0])


### PR DESCRIPTION
## Summary
Enhanced the land/ocean offset check to sample multiple time steps instead of checking only a single time slice. This provides better temporal coverage validation and helps identify time-dependent data quality issues.

## Key Changes

- **Temporal sampling**: The check now samples three time indices (start, middle, end) when time dimension exists, instead of checking only the last time step
- **Per-time-step results**: Added `time_results` field to track mismatches for each sampled time step individually
- **Status refinement**: Introduced "warn" status when some (but not all) time steps fail, with "fail" reserved for when all time steps fail
- **Enhanced reporting**: 
  - Added `sampled_time_indices` field to report which time indices were checked
  - Mismatch entries now include `time_index` and `time_value` fields for temporal context
  - Updated point counts to reflect total checks across all time steps
- **Suggested fix**: When status is "warn", the check now suggests running the `time_cover` check to investigate temporal coverage issues
- **UI improvements**:
  - Rich console output now displays a "Time" column in mismatch tables when time data is available
  - Added "Land/Ocean Offset Details" section showing time indices checked and missing point counts
  - HTML report similarly enhanced with time column and metadata section

## Implementation Details

- Time indices are deduplicated (e.g., if dataset has only 2 time steps, [0, 1, 1] becomes [0, 1])
- Changed initial section selection from last time step to first time step for consistency
- Mismatches are aggregated across all time steps in the main report while preserving per-time-step details
- The check remains skipped for boolean dtype data (unchanged behavior)

https://claude.ai/code/session_01KtUnpCqRRrinr3JhM9r519