### PR TITLE
Treat all-skipped checks as passing and improve status reporting

### DIFF
--- a/src/nc_check/engine/suite.py
+++ b/src/nc_check/engine/suite.py
@@ -24,10 +24,13 @@ def _summary_from_checks(checks: list[dict[str, Any]]) -> dict[str, Any]:
     failing_checks = sum(1 for kind in kinds if kind == "fail")
     warning_checks = sum(1 for kind in kinds if kind == "warn")
     warnings_or_skips = sum(1 for kind in kinds if kind in {"warn", "skip"})
+    skip_checks = sum(1 for kind in kinds if kind == "skip")
     if failing_checks > 0:
         overall_status = "fail"
     elif warning_checks > 0:
         overall_status = "warn"
+    elif len(checks) > 0 and skip_checks == len(checks):
+        overall_status = "skip"
     else:
         overall_status = "pass"
     return {
@@ -35,7 +38,7 @@ def _summary_from_checks(checks: list[dict[str, Any]]) -> dict[str, Any]:
         "failing_checks": failing_checks,
         "warnings_or_skips": warnings_or_skips,
         "overall_status": overall_status,
-        "overall_ok": overall_status == "pass",
+        "overall_ok": overall_status in {"pass", "skip"},
     }
 
 

--- a/src/nc_check/formatting.py
+++ b/src/nc_check/formatting.py
@@ -752,7 +752,7 @@ def _render_ocean_reports_top_summary_with_rich(
         summary_rows.append(
             (
                 _stringify(report.get("variable")),
-                report.get("ok"),
+                _ocean_variable_status(report),
                 " ".join(detail_parts),
             )
         )
@@ -865,7 +865,7 @@ def _render_time_cover_reports_top_summary_with_rich(
         summary_rows.append(
             (
                 _stringify(report.get("variable")),
-                report.get("ok"),
+                _time_cover_variable_status(report),
                 " ".join(detail_parts),
             )
         )


### PR DESCRIPTION
## Summary
This PR improves the handling of skipped checks in test suites and fixes status reporting in ocean and time coverage summaries.

## Key Changes
- **Suite summary logic**: When all checks in a suite are skipped, the overall status is now set to "skip" instead of "pass"
- **Overall OK status**: Updated to consider both "pass" and "skip" statuses as acceptable outcomes (changed from only "pass")
- **Ocean reports**: Replace direct `ok` field access with `_ocean_variable_status()` function for proper status determination
- **Time coverage reports**: Replace direct `ok` field access with `_time_cover_variable_status()` function for proper status determination

## Implementation Details
- Added `skip_checks` counter to track the number of skipped checks
- Added conditional logic to set `overall_status = "skip"` when all checks are skipped
- Updated `overall_ok` to use set membership check (`in {"pass", "skip"}`) for clearer intent
- Delegated status rendering to dedicated helper functions for ocean and time coverage reports, allowing for more sophisticated status determination logic

https://claude.ai/code/session_019jcZu7HGKLsfJohR2zXctK